### PR TITLE
fix: change delimiter to avoid conflicts with empty values

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -11,7 +11,7 @@ RESURRECT_FILE_EXTENSION="txt"
 _RESURRECT_DIR=""
 _RESURRECT_FILE_PATH=""
 
-d=$'\t'
+d=$'\t;\t'
 
 # helper functions
 get_tmux_option() {

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -8,7 +8,7 @@ source "$CURRENT_DIR/process_restore_helpers.sh"
 source "$CURRENT_DIR/spinner_helpers.sh"
 
 # delimiter
-d=$'\t'
+d=$'\t;\t'
 
 # Global variable.
 # Used during the restore: if a pane already exists from before, it is
@@ -306,7 +306,7 @@ restore_window_properties() {
 restore_all_pane_processes() {
 	if restore_pane_processes_enabled; then
 		local pane_full_command
-		awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $11 !~ "^:$" { print $2, $3, $6, $8, $11; }' $(last_resurrect_file) |
+		awk 'BEGIN { FS="\t;\t"; OFS="\t;\t" } /^pane/ && $11 !~ "^:$" { print $2, $3, $6, $8, $11; }' $(last_resurrect_file) |
 			while IFS=$d read -r session_name window_number pane_index dir pane_full_command; do
 				dir="$(remove_first_char "$dir")"
 				pane_full_command="$(remove_first_char "$pane_full_command")"
@@ -316,7 +316,7 @@ restore_all_pane_processes() {
 }
 
 restore_active_pane_for_each_window() {
-	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $9 == 1 { print $2, $3, $6; }' $(last_resurrect_file) |
+	awk 'BEGIN { FS="\t;\t"; OFS="\t;\t" } /^pane/ && $9 == 1 { print $2, $3, $6; }' $(last_resurrect_file) |
 		while IFS=$d read session_name window_number active_pane; do
 			tmux switch-client -t "${session_name}:${window_number}"
 			tmux select-pane -t "$active_pane"
@@ -324,7 +324,7 @@ restore_active_pane_for_each_window() {
 }
 
 restore_zoomed_windows() {
-	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $5 ~ /Z/ && $9 == 1 { print $2, $3; }' $(last_resurrect_file) |
+	awk 'BEGIN { FS="\t;\t"; OFS="\t;\t" } /^pane/ && $5 ~ /Z/ && $9 == 1 { print $2, $3; }' $(last_resurrect_file) |
 		while IFS=$d read session_name window_number; do
 			tmux resize-pane -t "${session_name}:${window_number}" -Z
 		done
@@ -340,7 +340,7 @@ restore_grouped_sessions() {
 }
 
 restore_active_and_alternate_windows() {
-	awk 'BEGIN { FS="\t"; OFS="\t" } /^window/ && $6 ~ /[*-]/ { print $2, $5, $3; }' $(last_resurrect_file) |
+	awk 'BEGIN { FS="\t;\t"; OFS="\t;\t" } /^window/ && $6 ~ /[*-]/ { print $2, $5, $3; }' $(last_resurrect_file) |
 		sort -u |
 		while IFS=$d read session_name active_window window_number; do
 			tmux switch-client -t "${session_name}:${window_number}"

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -7,8 +7,8 @@ source "$CURRENT_DIR/helpers.sh"
 source "$CURRENT_DIR/spinner_helpers.sh"
 
 # delimiters
-d=$'\t'
-delimiter=$'\t'
+d=$'\t;\t'
+delimiter=$'\t;\t'
 
 # if "quiet" script produces no output
 SCRIPT_OUTPUT="$1"


### PR DESCRIPTION
> [!IMPORTANT] 
> copied from #536
---
I realized that when some values were empty, it would cause unexpected behavior and cannot restore correctly. ![image](https://private-user-images.githubusercontent.com/91678288/416525375-9b07b38a-1625-4f2c-8dc5-efed7490c30e.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTMxMjA1MzUsIm5iZiI6MTc1MzEyMDIzNSwicGF0aCI6Ii85MTY3ODI4OC80MTY1MjUzNzUtOWIwN2IzOGEtMTYyNS00ZjJjLThkYzUtZWZlZDc0OTBjMzBlLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA3MjElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNzIxVDE3NTAzNVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTBlODdlMjU0ZThlZjRkNzEzNzJhM2FmMjY0ZjRmOTk2NmZkMTZjZWYxMTlkZDUwOGI0NGFmYjMyMTM4Y2I5MmYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.MgDTsAezB6XnOpBP2QFdPKDgA-RwOCSi8XdltQwNpkE)
 
Therefore, I changes the delimiter from `\t` to `\t;\t`, and it fixes all the problems. ![image](https://private-user-images.githubusercontent.com/91678288/416526111-4a199519-8487-4d2e-aeeb-ada5aa90932d.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTMxMjA1MzUsIm5iZiI6MTc1MzEyMDIzNSwicGF0aCI6Ii85MTY3ODI4OC80MTY1MjYxMTEtNGExOTk1MTktODQ4Ny00ZDJlLWFlZWItYWRhNWFhOTA5MzJkLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA3MjElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNzIxVDE3NTAzNVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTI1MmU5MWVmMmQyNDUyNDI3NWVkNzE1MDliNmY1ZmViZDZjY2Y4NmFjNWI5ODA3YzMxMGRjMjI4M2RmZDRmNGYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.d4KUiQkZpVQHLejeJ18SkpBb8Fi9ZWdH8vk8T-8vaZo)
