### PR TITLE
fix: remove/unlink run_tests because it points to nothing.

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -1,1 +1,0 @@
-lib/tmux-test/run_tests

--- a/tests/helpers/helpers.sh
+++ b/tests/helpers/helpers.sh
@@ -1,1 +1,0 @@
-../../lib/tmux-test/tests/helpers/helpers.sh

--- a/tests/run_tests_in_isolation
+++ b/tests/run_tests_in_isolation
@@ -1,1 +1,0 @@
-../lib/tmux-test/tests/run_tests_in_isolation


### PR DESCRIPTION
> [!IMPORTANT]
> copied from #533
---
this pull request removes the `run_tests`, `tests/helpers/helpers.sh`, `tests/run_tests_in_isolation` files that exists for 10 years and these files are actually symlinks that points to nothing so why not remove it?
 
![Screenshot_20250130-135539](https://private-user-images.githubusercontent.com/115651305/408008210-aabe67c9-3b98-4ff0-b977-88cf54593bfb.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTMxMjA3ODUsIm5iZiI6MTc1MzEyMDQ4NSwicGF0aCI6Ii8xMTU2NTEzMDUvNDA4MDA4MjEwLWFhYmU2N2M5LTNiOTgtNGZmMC1iOTc3LTg4Y2Y1NDU5M2JmYi5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwNzIxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDcyMVQxNzU0NDVaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1hY2Y5M2I4YTc4MjY4ZGQxZGI0ODg2YjZkZDczNGIxNWFkZDg3OWQzZGNkM2Y3ZDRmYTQ1NjUzYzBiODI0ZWJkJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.bZ0NrqBZGyFoLsJHKawfVfNrFSgS5S5akEgjObjZ2f4)